### PR TITLE
Bitwise compat

### DIFF
--- a/RunTests.lua
+++ b/RunTests.lua
@@ -26,7 +26,15 @@ local tests = {
 
 for k,v in pairs(tests) do
 	print(String.format("Running %s...",v));
-	require("test."..v);
-	print(String.format("%s passed!\n",v));
+	local ok, err = pcall(
+	function()
+		require("test."..v)
+	end
+	);
+	if not ok then
+		print(String.format("FAIL: %s failed with error:\n%s\n", v, err));
+	else
+		print(String.format("%s passed!\n",v));
+	end
 end
 

--- a/lockbox/cipher/aes128.lua
+++ b/lockbox/cipher/aes128.lua
@@ -1,7 +1,7 @@
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 

--- a/lockbox/cipher/aes192.lua
+++ b/lockbox/cipher/aes192.lua
@@ -1,7 +1,7 @@
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 

--- a/lockbox/cipher/aes256.lua
+++ b/lockbox/cipher/aes256.lua
@@ -1,7 +1,7 @@
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 

--- a/lockbox/cipher/des.lua
+++ b/lockbox/cipher/des.lua
@@ -3,7 +3,7 @@ require("lockbox").insecure();
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 

--- a/lockbox/cipher/mode/cbc.lua
+++ b/lockbox/cipher/mode/cbc.lua
@@ -3,7 +3,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local CBC = {};
 

--- a/lockbox/cipher/mode/cfb.lua
+++ b/lockbox/cipher/mode/cfb.lua
@@ -3,7 +3,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local CFB = {};
 

--- a/lockbox/cipher/mode/ctr.lua
+++ b/lockbox/cipher/mode/ctr.lua
@@ -3,7 +3,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local AND = Bit.band;
 local OR  = Bit.bor;

--- a/lockbox/cipher/mode/ecb.lua
+++ b/lockbox/cipher/mode/ecb.lua
@@ -5,7 +5,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local ECB = {};
 

--- a/lockbox/cipher/mode/ofb.lua
+++ b/lockbox/cipher/mode/ofb.lua
@@ -3,7 +3,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local OFB = {};
 

--- a/lockbox/cipher/mode/pcbc.lua
+++ b/lockbox/cipher/mode/pcbc.lua
@@ -3,7 +3,7 @@ local Stream = require("lockbox.util.stream");
 local Queue = require("lockbox.util.queue");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local PCBC = {};
 

--- a/lockbox/cipher/tea.lua
+++ b/lockbox/cipher/tea.lua
@@ -4,7 +4,7 @@ local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 local AND = Bit.band;

--- a/lockbox/cipher/xtea.lua
+++ b/lockbox/cipher/xtea.lua
@@ -4,7 +4,7 @@ local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local Math = require("math");
 
 local AND = Bit.band;

--- a/lockbox/digest/md2.lua
+++ b/lockbox/digest/md2.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Queue = require("lockbox.util.queue");
 

--- a/lockbox/digest/md4.lua
+++ b/lockbox/digest/md4.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/md5.lua
+++ b/lockbox/digest/md5.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/ripemd128.lua
+++ b/lockbox/digest/ripemd128.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/ripemd160.lua
+++ b/lockbox/digest/ripemd160.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/sha1.lua
+++ b/lockbox/digest/sha1.lua
@@ -1,6 +1,6 @@
 require("lockbox").insecure();
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/sha2_224.lua
+++ b/lockbox/digest/sha2_224.lua
@@ -1,4 +1,4 @@
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/digest/sha2_256.lua
+++ b/lockbox/digest/sha2_256.lua
@@ -1,4 +1,4 @@
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Math = require("math");
 local Queue = require("lockbox.util.queue");

--- a/lockbox/kdf/pbkdf2.lua
+++ b/lockbox/kdf/pbkdf2.lua
@@ -1,4 +1,4 @@
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Array = require("lockbox.util.array");
 local Stream = require("lockbox.util.stream");

--- a/lockbox/mac/hmac.lua
+++ b/lockbox/mac/hmac.lua
@@ -1,4 +1,4 @@
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");

--- a/lockbox/util/array.lua
+++ b/lockbox/util/array.lua
@@ -1,6 +1,6 @@
 
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local XOR = Bit.bxor;
 

--- a/lockbox/util/base64.lua
+++ b/lockbox/util/base64.lua
@@ -1,5 +1,5 @@
 local String = require("string");
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 
 local Array = require("lockbox.util.array");
 local Stream = require("lockbox.util.stream");

--- a/lockbox/util/bit.lua
+++ b/lockbox/util/bit.lua
@@ -1,0 +1,23 @@
+local ok, e
+if not ok then
+	ok, e = pcall(require, "bit") -- the LuaJIT one ?
+end
+if not ok then
+	ok, e = pcall(require, "bit32") -- Lua 5.2
+end
+if not ok then
+	ok, e = pcall(require, "bit.numberlua") -- for Lua 5.1, https://github.com/tst2005/lua-bit-numberlua/
+end
+if not ok then
+	error("no bitwise support found", 2)
+end
+
+-- Workaround to support Lua 5.2 bit32 API with the LuaJIT bit one
+if e.rol and not e.lrotate then
+	e.lrotate = e.rol
+end
+if e.ror and not e.rrotate then
+	e.rrotate = e.ror
+end
+
+return e

--- a/test/HMACTests.lua
+++ b/test/HMACTests.lua
@@ -1,4 +1,4 @@
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");

--- a/test/PBKDF2Tests.lua
+++ b/test/PBKDF2Tests.lua
@@ -2,7 +2,7 @@ local PBKDF2 = require("lockbox.kdf.pbkdf2");
 local HMAC = require("lockbox.mac.hmac");
 local SHA1 = require("lockbox.digest.sha1");
 
-local Bit = require("bit32");
+local Bit = require("lockbox.util.bit");
 local String = require("string");
 local Stream = require("lockbox.util.stream");
 local Array = require("lockbox.util.array");


### PR DESCRIPTION
I tried to add a generic bitwise module support.
Lua 5.1 doesn't have native bit module
Lua 5.2 have one named bit32
LuaJIT have one named bit (similar to bit32 but not exactly the same)

I also found a 100% lua implementation, theoricaly allowing support for all version (mostly Lua 5.1).
See https://github.com/davidm/lua-bit-numberlua
I decide to create a lockbox.util.bit to use only one API internaly.

Current status : 
 * FAIL: Lua 5.1 (internaly using bit.numberlua) : I supposed it's a bit.numberlua bug...
 * PASS: Lua 5.2 : all tests passed (internaly using bit32
 * PASS: LuaJIT (2.0) : all tests passed (internaly using bit)

