### PR TITLE
Add luacheck rc

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+include_files = {
+    "**/*.lua"
+}
+
+exclude_files = {
+    ".env/**/*.lua",
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,5 +3,7 @@ include_files = {
 }
 
 exclude_files = {
-    ".env/**/*.lua",
+    ".*/**/*.*",
+    ".lua/bin/lua",
+    ".lua/bin/luac",
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 >I'm afraid I've run out of free time to work on the Lockbox, so I'm looking for anyone interested in maintaining/growing the project.  If you're interested, open an issue and request to be a collaborator.
 ---
 # The Lua Lockbox
-[![Build Status](https://travis-ci.com/somesocks/lua-lockbox.svg)](https://travis-ci.com/somesocks/lua-lockbox) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.com/somesocks/lua-lockbox.svg)](https://travis-ci.com/somesocks/lua-lockbox) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Luacheck](https://github.com/somesocks/lua-lockbox/workflows/Luacheck/badge.svg)](https://github.com/somesocks/lua-lockbox/actions)
 
 A collection of cryptographic primitives and protocols written in pure Lua.  This was written to provide cross-platform, tested reference implementations of many different cryptographic primitives.  These are written to be easy to read and easy to use, not for performance!
 


### PR DESCRIPTION
After we run `script/tests` it creates folders like `.env`  so you could see [here](https://github.com/somesocks/lua-lockbox/runs/1665202358?check_suite_focus=true) that it fails for luacheck. Instead we might better exclude all of this unwanted generated folders and `luacheck` would be green.

Also adding badge to README because it is beautiful ^^ 