### PR TITLE
Update rockspec source urls to use https

### DIFF
--- a/rockspecs/lockbox-0.1.0-0.rockspec
+++ b/rockspecs/lockbox-0.1.0-0.rockspec
@@ -1,7 +1,7 @@
 package = "lockbox"
 version = "0.1.0-0"
 source = {
-	url = "git://github.com/somesocks/lua-lockbox.git",
+	url = "git+https://github.com/somesocks/lua-lockbox.git",
 	tag = "0.1.0"
 }
 description = {

--- a/rockspecs/lockbox-scm-0.rockspec
+++ b/rockspecs/lockbox-scm-0.rockspec
@@ -1,7 +1,7 @@
 package = "lockbox"
 version = "scm-0"
 
-source = { url = "git://github.com/somesocks/lua-lockbox.git" }
+source = { url = "git+https://github.com/somesocks/lua-lockbox.git" }
 
 description = {
   summary = "A collection of cryptographic primitives written in pure Lua",


### PR DESCRIPTION
Because https://github.blog/2021-09-01-improving-git-protocol-security-github/, the rock fails to install.