### PR TITLE
Fix bug in PKCS7 padding count

### DIFF
--- a/lockbox/padding/pkcs7.lua
+++ b/lockbox/padding/pkcs7.lua
@@ -1,6 +1,5 @@
 local PKCS7Padding = function(blockSize, byteCount)
-
-    local paddingCount = blockSize - ((byteCount -1) % blockSize) + 1;
+    local paddingCount = blockSize - (((byteCount - 1) % blockSize) + 1);
     local bytesLeft = paddingCount;
 
     local stream = function()


### PR DESCRIPTION
Closes #14 

This fixes an off by one error in the PKCS7 implementation. Existing unit tests pass 