### PR TITLE
Add string conversion for modes, macs and digests

### DIFF
--- a/lockbox/cipher/mode/cbc.lua
+++ b/lockbox/cipher/mode/cbc.lua
@@ -77,6 +77,10 @@ CBC.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -154,6 +158,10 @@ CBC.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/cfb.lua
+++ b/lockbox/cipher/mode/cfb.lua
@@ -78,6 +78,10 @@ CFB.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -154,6 +158,10 @@ CFB.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/ctr.lua
+++ b/lockbox/cipher/mode/ctr.lua
@@ -120,6 +120,10 @@ CTR.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -235,6 +239,10 @@ CTR.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/ecb.lua
+++ b/lockbox/cipher/mode/ecb.lua
@@ -72,6 +72,10 @@ ECB.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -140,6 +144,10 @@ ECB.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/ige.lua
+++ b/lockbox/cipher/mode/ige.lua
@@ -82,6 +82,10 @@ IGE.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -162,6 +166,10 @@ IGE.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/ofb.lua
+++ b/lockbox/cipher/mode/ofb.lua
@@ -78,6 +78,10 @@ OFB.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -154,6 +158,10 @@ OFB.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/cipher/mode/pcbc.lua
+++ b/lockbox/cipher/mode/pcbc.lua
@@ -78,6 +78,10 @@ PCBC.Cipher = function()
         return Stream.toArray(outputQueue.pop);
     end
 
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
+    end
+
     return public;
 
 end
@@ -154,6 +158,10 @@ PCBC.Decipher = function()
 
     public.asBytes = function()
         return Stream.toArray(outputQueue.pop);
+    end
+
+    public.asString = function()
+        return Stream.toString(outputQueue.pop);
     end
 
     return public;

--- a/lockbox/digest/md2.lua
+++ b/lockbox/digest/md2.lua
@@ -128,6 +128,12 @@ local MD2 = function()
                 X[ 8], X[ 9], X[10], X[11], X[12], X[13], X[14], X[15]);
     end
 
+    public.asString = function()
+        return string.pack(string.rep('B', 16),
+                X[ 0], X[ 1], X[ 2], X[ 3], X[ 4], X[ 5], X[ 6], X[ 7],
+                X[ 8], X[ 9], X[10], X[11], X[12], X[13], X[14], X[15]);
+    end
+
     return public;
 
 end

--- a/lockbox/digest/md4.lua
+++ b/lockbox/digest/md4.lua
@@ -198,6 +198,16 @@ local MD4 = function()
                 b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15);
     end
 
+    public.asString = function()
+        local  b0, b1, b2, b3 = word2bytes(A);
+        local  b4, b5, b6, b7 = word2bytes(B);
+        local  b8, b9, b10, b11 = word2bytes(C);
+        local b12, b13, b14, b15 = word2bytes(D);
+
+        return string.pack(string.rep('B', 16),
+                b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15);
+    end
+
     return public;
 
 end

--- a/lockbox/digest/md5.lua
+++ b/lockbox/digest/md5.lua
@@ -182,6 +182,18 @@ local MD5 = function()
                 b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15);
     end
 
+    public.asString = function()
+        local b0, b1, b2, b3 = word2bytes(A);
+        local b4, b5, b6, b7 = word2bytes(B);
+        local b8, b9, b10, b11 = word2bytes(C);
+        local b12, b13, b14, b15 = word2bytes(D);
+
+        return string.pack(string.rep('B', 16),
+            b0, b1, b2, b3, b4, b5, b6, b7, b8,
+            b9, b10, b11, b12, b13, b14, b15
+        )
+    end
+
     return public;
 
 end

--- a/lockbox/digest/ripemd128.lua
+++ b/lockbox/digest/ripemd128.lua
@@ -335,6 +335,17 @@ local RIPEMD128 = function()
                 b10, b11, b12, b13, b14, b15);
     end
 
+    public.asString = function()
+        local  b0, b1, b2, b3 = word2bytes(A);
+        local  b4, b5, b6, b7 = word2bytes(B);
+        local  b8, b9, b10, b11 = word2bytes(C);
+        local b12, b13, b14, b15 = word2bytes(D);
+
+        return string.pack(string.rep('B', 16),
+                b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,
+                b10, b11, b12, b13, b14, b15);
+    end
+
     return public;
 
 end

--- a/lockbox/digest/ripemd160.lua
+++ b/lockbox/digest/ripemd160.lua
@@ -386,6 +386,18 @@ local RIPEMD160 = function()
                 b10, b11, b12, b13, b14, b15, b16, b17, b18, b19);
     end
 
+    public.asString = function()
+        local  b0, b1, b2, b3 = word2bytes(A);
+        local  b4, b5, b6, b7 = word2bytes(B);
+        local  b8, b9, b10, b11 = word2bytes(C);
+        local b12, b13, b14, b15 = word2bytes(D);
+        local b16, b17, b18, b19 = word2bytes(E);
+
+        return string.pack(string.rep('B', 20),
+                 b0, b1, b2, b3, b4, b5, b6, b7, b8, b9,
+                b10, b11, b12, b13, b14, b15, b16, b17, b18, b19);
+    end
+
     return public;
 
 end

--- a/lockbox/digest/sha1.lua
+++ b/lockbox/digest/sha1.lua
@@ -167,6 +167,17 @@ local SHA1 = function()
                 b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19);
     end
 
+    public.asString = function()
+        local  b0, b1, b2, b3 = word2bytes(h0);
+        local  b4, b5, b6, b7 = word2bytes(h1);
+        local  b8, b9, b10, b11 = word2bytes(h2);
+        local b12, b13, b14, b15 = word2bytes(h3);
+        local b16, b17, b18, b19 = word2bytes(h4);
+
+        return string.pack(string.rep('B', 20),
+                b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17, b18, b19);
+    end
+
     return public;
 end
 

--- a/lockbox/digest/sha2_224.lua
+++ b/lockbox/digest/sha2_224.lua
@@ -192,6 +192,20 @@ local SHA2_224 = function()
                 , b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27);
     end
 
+    public.asString = function()
+        local  b0, b1, b2, b3 = word2bytes(h0);
+        local  b4, b5, b6, b7 = word2bytes(h1);
+        local  b8, b9, b10, b11 = word2bytes(h2);
+        local b12, b13, b14, b15 = word2bytes(h3);
+        local b16, b17, b18, b19 = word2bytes(h4);
+        local b20, b21, b22, b23 = word2bytes(h5);
+        local b24, b25, b26, b27 = word2bytes(h6);
+
+        return string.pack(string.rep('B', 28),
+            b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13,
+            b14, b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27);
+    end
+
     return public;
 
 end

--- a/lockbox/digest/sha2_256.lua
+++ b/lockbox/digest/sha2_256.lua
@@ -195,6 +195,23 @@ local SHA2_256 = function()
                 , b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30, b31);
     end
 
+    public.asString = function()
+        local b0, b1, b2, b3 = word2bytes(h0);
+        local b4, b5, b6, b7 = word2bytes(h1);
+        local b8, b9, b10, b11 = word2bytes(h2);
+        local b12, b13, b14, b15 = word2bytes(h3);
+        local b16, b17, b18, b19 = word2bytes(h4);
+        local b20, b21, b22, b23 = word2bytes(h5);
+        local b24, b25, b26, b27 = word2bytes(h6);
+        local b28, b29, b30, b31 = word2bytes(h7);
+
+        return string.pack(string.rep('B', 32),
+            b0, b1, b2, b3, b4, b5, b6, b7, b8,
+            b9, b10, b11, b12, b13, b14, b15,
+            b16, b17, b18, b19, b20, b21, b22, b23, b24,
+            b25, b26, b27, b28, b29, b30, b31);
+    end
+
     return public;
 
 end

--- a/lockbox/kdf/hkdf.lua
+++ b/lockbox/kdf/hkdf.lua
@@ -99,6 +99,10 @@ local HKDF = function()
         return Array.toHex(secret);
     end
 
+    public.asString = function()
+        return Array.toString(secret);
+    end
+
     return public;
 end
 

--- a/lockbox/kdf/pbkdf2.lua
+++ b/lockbox/kdf/pbkdf2.lua
@@ -108,6 +108,10 @@ local PBKDF2 = function()
         return Array.toHex(dKey);
     end
 
+    public.asString = function()
+        return Array.toString(dKey);
+    end
+
     return public;
 end
 

--- a/lockbox/mac/hmac.lua
+++ b/lockbox/mac/hmac.lua
@@ -78,6 +78,10 @@ local HMAC = function()
         return digest.asHex();
     end
 
+    public.asString = function()
+        return digest.asString();
+    end
+
     return public;
 
 end


### PR DESCRIPTION
Adds `asString` conversions for primitives alongside the existing `asHex` and `asBytes`. This prevents the need for creating a bunch of intermediary objects when strings are needed.