### PR TITLE
Added workaround for bit operaitions in incomplete environments 

### DIFF
--- a/lockbox/util/bit.lua
+++ b/lockbox/util/bit.lua
@@ -22,4 +22,23 @@ if e.ror and not e.rrotate then
     e.rrotate = e.ror
 end
 
+-- Workaround to support incomplete bit operations set
+if not e.ror and not e.rrotate then
+    local ror = function(b, n)
+        return e.bor(e.rshift(b, n), e.lshift(b, 32 - n))
+    end
+
+    e.ror = ror
+    e.rrotate = ror
+end
+
+if not e.rol and not e.lrotate then
+    local ror = function(b, n)
+        return e.bor(e.lshift(b, n), e.rshift(b, 32 - n))
+    end
+
+    e.rol = ror
+    e.lrotate = ror
+end
+
 return e


### PR DESCRIPTION
Added workaround to add necessary functions. It will be helpful in environments, where not all necessary bit functions exists